### PR TITLE
Fix for torchvision>=0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ tensorboard==1.14.0
 tensorflow==1.15.4
 tensorflow-estimator==1.14.0
 tqdm==4.36.1
+pytorch==1.6.0
+torchvision==0.7.0

--- a/train.py
+++ b/train.py
@@ -246,9 +246,9 @@ class Trainer:
             # Train Discriminator
             if self.epoch > self.opt.discr_train_epoch:
                 loss_G.backward(retain_graph=True)
-                self.model_optimizer.step()
                 self.model_optimizer_D.zero_grad()
                 loss_D.backward()
+                self.model_optimizer.step()
                 self.model_optimizer_D.step()
             else:
                 losses["loss"].backward()


### PR DESCRIPTION
This pull request solves the following:
- Missing packages in requirements.txt
- Prevents the "RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation" error. 

It seems that error checking for inplace operation was added after torchvision 0.4, sometime this year. I trained the model after making these changes, so it should work for newer PyTorch versions.